### PR TITLE
Add support for exact matches

### DIFF
--- a/assertions.go
+++ b/assertions.go
@@ -1,0 +1,1 @@
+package commander

--- a/commander_test.go
+++ b/commander_test.go
@@ -206,3 +206,49 @@ func TestMatch(t *testing.T) {
 	assert.True(t, isMatch)
 	assert.NotNil(t, properties)
 }
+
+func TestExactMatch(t *testing.T) {
+	properties, isMatch := NewCommand("help", WithExactMatch(true)).Match("help")
+	assert.True(t, isMatch)
+	assert.NotNil(t, properties)
+
+	properties, isMatch = NewCommand("help", WithExactMatch(true)).Match("  help")
+	assert.True(t, isMatch)
+	assert.NotNil(t, properties)
+
+	properties, isMatch = NewCommand("help", WithExactMatch(true)).Match("help  ")
+	assert.True(t, isMatch)
+	assert.NotNil(t, properties)
+
+	properties, isMatch = NewCommand("help", WithExactMatch(true)).Match("please help")
+	assert.False(t, isMatch)
+	assert.Nil(t, properties)
+
+	properties, isMatch = NewCommand("help", WithExactMatch(true)).Match("help me")
+	assert.False(t, isMatch)
+	assert.Nil(t, properties)
+
+	properties, isMatch = NewCommand("echo <text>", WithExactMatch(true)).Match("echo")
+	assert.False(t, isMatch)
+	assert.Nil(t, properties)
+
+	properties, isMatch = NewCommand("echo <text>", WithExactMatch(true)).Match("echo  ")
+	assert.False(t, isMatch)
+	assert.Nil(t, properties)
+
+	properties, isMatch = NewCommand("echo <text>", WithExactMatch(true)).Match("  echo")
+	assert.False(t, isMatch)
+	assert.Nil(t, properties)
+
+	properties, isMatch = NewCommand("echo <text>", WithExactMatch(true)).Match("  echo hello world")
+	assert.True(t, isMatch)
+	assert.Equal(t, properties.StringParam("text", ""), "hello world")
+
+	properties, isMatch = NewCommand("echo <text>", WithExactMatch(true)).Match("blah echo hello world")
+	assert.False(t, isMatch)
+	assert.Nil(t, properties)
+
+	properties, isMatch = NewCommand("echo <text>", WithExactMatch(true)).Match("echo 1")
+	assert.True(t, isMatch)
+	assert.Equal(t, properties.StringParam("text", ""), "1")
+}

--- a/pattern_set.go
+++ b/pattern_set.go
@@ -1,0 +1,31 @@
+package commander
+
+type patternSet struct {
+	PreCommandPattern  string
+	PostCommandPattern string
+	InputPattern       string
+	LazyInputPattern   string
+	SpacePattern       string
+	MatchOffset        int
+	ExactMatch         bool
+}
+
+var defaultCommandPatternSet = patternSet{
+	PreCommandPattern:  "(\\s|^)",
+	PostCommandPattern: "(\\s|$)",
+	InputPattern:       "(.+)",
+	LazyInputPattern:   "(.+?)",
+	SpacePattern:       "\\s+",
+	MatchOffset:        2,
+	ExactMatch:         false,
+}
+
+var exactMatchPatternSet = patternSet{
+	PreCommandPattern:  "(^(\\s+)?)",
+	PostCommandPattern: "((\\s+)?$)",
+	InputPattern:       "(\\S.*)",
+	LazyInputPattern:   "(\\S.*?)",
+	SpacePattern:       "\\s+",
+	MatchOffset:        3,
+	ExactMatch:         true,
+}


### PR DESCRIPTION
This lets us avoid accidentally matching short commands based on their
appearances in longer blocks of text. For instance, if someone mentions
"help" in an argument, it won't match a "help" command any longer. We
require the commands to have a more strict structure when passing
WithExactMatch.