### PR TITLE
Avoid registering nil expressions

### DIFF
--- a/commander.go
+++ b/commander.go
@@ -120,7 +120,9 @@ func generate(tokens []*Token) []*regexp.Regexp {
 
 	for index := len(tokens) - 1; index >= -1; index-- {
 		regex := compile(create(tokens, index))
-		regexps = append(regexps, regex)
+		if regex != nil {
+			regexps = append(regexps, regex)
+		}
 	}
 
 	return regexps

--- a/commander_test.go
+++ b/commander_test.go
@@ -232,3 +232,30 @@ func TestMatch(t *testing.T) {
 	assert.True(t, isMatch)
 	assert.NotNil(t, properties)
 }
+
+func TestNewCommand(t *testing.T) {
+	tests := []struct {
+		name           string
+		in             string
+		wantTokens     int
+		wantExpresions int
+	}{
+		{"simple command", "ping", 1, 2},
+		{"command and parameter", "say <input>", 2, 3},
+		{"no command", "", 0, 0},
+		{"all tokens are parameter", "<a> <123> <a123> <a-123> <a.123>", 5, 5},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := NewCommand(tt.in)
+			if got := len(cmd.tokens); got != tt.wantTokens {
+				t.Errorf("got tokens %v, want %v", got, tt.wantTokens)
+			}
+			if got := len(cmd.expressions); got != tt.wantExpresions {
+				t.Errorf("got expressions %v, want %v", got, tt.wantExpresions)
+			}
+			// Check no panic
+			_, _ = cmd.Match("")
+		})
+	}
+}


### PR DESCRIPTION
Hi @shomali11. I use https://github.com/shomali11/slacker conveniently. Thank you.

I have encountered an error while using slacker ( `v2.0.0-alpha1` and `v2.0.0-alpha2` ) this time and came here to suggest a fix.

I have also added a test code to reproduce it.
If this fix does not suit you, please do not bother with this pull request and fix it otherwise.

## Summary

If all tokens of the command are parameters, nil is registered in the expressions. Then, when the Match method is executed, it becomes panic.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x5e962d]

goroutine 749 [running]:
regexp.(*Regexp).FindStringSubmatch(0x0, {0x0, 0x0})
        /usr/local/go/src/regexp/regexp.go:1046 +0x4d
github.com/shomali11/commander.(*Command).Match(0xc00088ab10, {0x0, 0x0})
        /workdir/vendor/github.com/shomali11/commander/commander.go:67 +0x165
github.com/shomali11/slacker/v2.(*command).Match(0x0?, {0x0?, 0x0?})
        /workdir/vendor/github.com/shomali11/slacker/v2/command.go:49 +0x25
github.com/shomali11/slacker/v2.(*Slacker).handleMessageEvent(0xc000873e60, {0x1937f30, 0xc00011a050}, {0x1330120?, 0xc00118a000?})
        /workdir/vendor/github.com/shomali11/slacker/v2/slacker.go:480 +0x2e2
created by github.com/shomali11/slacker/v2.(*Slacker).Listen.func1
        /workdir/vendor/github.com/shomali11/slacker/v2/slacker.go:280 +0xa9c
```

Avoid nil registration to solve the above problem.